### PR TITLE
Attachment Manager outline

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/AttachmentManager.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/AttachmentManager.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023 by The VASSAL Development Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+package VASSAL.build.module;
+
+import VASSAL.counters.Attachment;
+import VASSAL.counters.Decorator;
+import VASSAL.counters.GamePiece;
+import VASSAL.tools.SequenceEncoder;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class AttachmentManager {
+
+  /**
+   * Map of the attachment traits with the same attachment names
+   */
+  final HashMap<String, List<Attachment>> attachments = new HashMap<>();
+
+  public AttachmentManager() {
+
+  }
+
+  public void clearAll() {
+    attachments.clear();
+  }
+
+  /**
+   * A piece has been added to the game state. Process any auto-attachments it has defined
+   * @param p
+   */
+  public void pieceAdded(GamePiece p) {
+    if (!(p instanceof Decorator)) {
+      return;
+    }
+    for (GamePiece piece : Decorator.getDecorators(p, Attachment.class)) {
+      final Attachment attachment = (Attachment) piece;
+      // if (attachment.isAutoAttach()) {
+      final String attachId = attachment.getAttachName();
+      List<Attachment> currentAttachments = attachments.get(attachId);
+      if (currentAttachments == null) {
+        currentAttachments = new ArrayList<>();
+      }
+      for (Attachment target : currentAttachments) {
+        // TODO Do attachy stuff betweem attachment and target
+      }
+      currentAttachments.add(attachment);
+      attachments.put(attachId, currentAttachments);
+      // }
+    }
+  }
+
+  /**
+   * A piece has been removed from the game state. Remove any auto-attachments it has defined
+   * @param p
+   */
+  public void pieceRemoved(GamePiece p) {
+    if (!(p instanceof Decorator)) {
+      return;
+    }
+    for (GamePiece piece : Decorator.getDecorators(p, Attachment.class)) {
+      final Attachment attachment = (Attachment) piece;
+      // if (attachment.isAutoAttach()) {
+      final String attachId = attachment.getAttachName();
+
+      // Remove any attachments
+      // TODO - Add code to detach this piece from all parents
+
+      // Clean the attachments array
+      final List<Attachment> currentAttachments = attachments.get(attachId);
+      if (currentAttachments != null) {
+        currentAttachments.remove(attachment);
+      }
+      attachments.put(attachId, currentAttachments);
+      // }
+    }
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -124,6 +124,7 @@ public class GameState implements CommandEncoder {
   protected String loadComments;
   protected boolean loadingInBackground = false;
   private boolean fastForwarding = false;
+  private AttachmentManager attachmentManager = new AttachmentManager();
 
   /**
    * @return true if currently loading in background
@@ -552,6 +553,7 @@ public class GameState implements CommandEncoder {
     lastSaveFile = null;
 
     if (gameStarted) {
+      attachmentManager.clearAll();
       if (gameStarting) {
         // Things that we invokeLater
         SwingUtilities.invokeLater(fastForwarding ? () -> {
@@ -1093,6 +1095,7 @@ public class GameState implements CommandEncoder {
     if (p.getId() == null) {
       p.setId(getNewPieceId());
     }
+    attachmentManager.pieceAdded(p);
     pieces.put(p.getId(), p);
   }
 
@@ -1109,6 +1112,12 @@ public class GameState implements CommandEncoder {
   public void removePiece(String id) {
     if (id != null) {
       pieces.remove(id);
+    }
+  }
+
+  public void removePiece(GamePiece piece) {
+    if (piece != null) {
+      removePiece(piece.getId());
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/command/RemovePiece.java
+++ b/vassal-app/src/main/java/VASSAL/command/RemovePiece.java
@@ -81,7 +81,7 @@ public class RemovePiece extends Command {
       m.repaint(r);
     }
 
-    GameModule.getGameModule().getGameState().removePiece(target.getId());
+    GameModule.getGameModule().getGameState().removePiece(target);
     KeyBuffer.getBuffer().remove(target);
   }
 

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -554,6 +554,27 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     return null;
   }
 
+  /**
+   * @return Working inward from this Trait/Decorator, finds and returns a list of all Decorators within the given GamePiece
+   * that is an instance of the given Class.
+   */
+  public static List<GamePiece> getDecorators(GamePiece p, Class<?> type) {
+    final ArrayList<GamePiece> list = new ArrayList<>();
+    GamePiece piece = p;
+    while (piece != null) {
+      if (type.isInstance(piece)) {
+        list.add(piece);
+      }
+      if (piece instanceof BasicPiece) {
+        piece = null;
+      }
+      else {
+        piece = getDecorator(piece, type);
+      }
+    }
+    return list;
+  }
+
 
   /**
    * {@link SearchTarget}


### PR DESCRIPTION
Hi Brian,

This is what I had in mind. See what you think.

It assumes that the attachment trait has an 'Auto-Attach' option which basically hides those hordes of confusing options. Attachments will be created auto-magically in each client when pieces are added and removed from the gamestate. No need for Commands, it will happen in each client. 

We may still need some of the policy options for auto-attach to (attach back etc,).